### PR TITLE
0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This changelog suppose to follow rules defined in the [changelog.md](https://cha
 
 ## 0.12.0 : 2024-11-07
 
+- **Added**: `entry_defaults` management command introduced and executed on server start
 - **Changed**: License files
 - **Fixed**: Catch `FileNotFoundError` in `/v1/data` endpoints
 - **Fixed**: Implicit Category creation in new Entry
+- **Fixed**: No not rely on existence of all keys in ISBN introspection driver
 
 ## 0.11.0 : 2024-10-10 (Too Drunk To Fuck)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog suppose to follow rules defined in the [changelog.md](https://cha
 - **Fixed**: Catch `FileNotFoundError` in `/v1/data` endpoints
 - **Fixed**: Implicit Category creation in new Entry
 - **Fixed**: No not rely on existence of all keys in ISBN introspection driver
+- **Fixed**: Keep usernames from LDAP always in lower
 
 ## 0.11.0 : 2024-10-10 (Too Drunk To Fuck)
 

--- a/apps/api/filters/entries.py
+++ b/apps/api/filters/entries.py
@@ -35,7 +35,7 @@ class EntryFilter(django_filters.FilterSet):
     feed_id = django_filters.UUIDFilter(field_name="feeds__id")
     published_at_gte = django_filters.CharFilter(method="filter_published_at_gte")
     published_at_lte = django_filters.CharFilter(method="filter_published_at_lte")
-    config__readium_enabled = django_filters.BooleanFilter(field_name='config__readium_enabled')
+    config__readium_enabled = django_filters.BooleanFilter(field_name="config__readium_enabled")
 
     @classmethod
     def template(cls) -> str:

--- a/apps/api/filters/entries.py
+++ b/apps/api/filters/entries.py
@@ -35,6 +35,7 @@ class EntryFilter(django_filters.FilterSet):
     feed_id = django_filters.UUIDFilter(field_name="feeds__id")
     published_at_gte = django_filters.CharFilter(method="filter_published_at_gte")
     published_at_lte = django_filters.CharFilter(method="filter_published_at_lte")
+    config__readium_enabled = django_filters.BooleanFilter(field_name='config__readium_enabled')
 
     @classmethod
     def template(cls) -> str:

--- a/apps/api/services/entry_introspection_service.py
+++ b/apps/api/services/entry_introspection_service.py
@@ -19,11 +19,11 @@ class IsbnDriver(IntrospectionDriver):
         data = meta(canonical(identifier))
 
         result = {
-            "publisher": data.get('Publisher'),
+            "publisher": data.get("Publisher"),
             "doi": None,
             "authors": [],
-            "year": data.get('Year'),
-            "language": data.get('Language'),
+            "year": data.get("Year"),
+            "language": data.get("Language"),
             "bibtex": bibformatters["bibtex"](data),
         }
 

--- a/apps/api/services/entry_introspection_service.py
+++ b/apps/api/services/entry_introspection_service.py
@@ -19,11 +19,11 @@ class IsbnDriver(IntrospectionDriver):
         data = meta(canonical(identifier))
 
         result = {
-            "publisher": data["Publisher"],
+            "publisher": data.get('Publisher'),
             "doi": None,
             "authors": [],
-            "year": data["Year"],
-            "language": data["Language"],
+            "year": data.get('Year'),
+            "language": data.get('Language'),
             "bibtex": bibformatters["bibtex"](data),
         }
 

--- a/apps/core/auth.py
+++ b/apps/core/auth.py
@@ -127,7 +127,7 @@ class BasicBackend(ModelBackend):
         try:
             user = User.objects.get(username=username)
         except User.DoesNotExist:
-            user = User(username=username, auth_source=auth_source)
+            user = User(username=username.lower(), auth_source=auth_source)
             user.set_unusable_password()
             user.save()
 

--- a/apps/core/auth.py
+++ b/apps/core/auth.py
@@ -127,7 +127,7 @@ class BasicBackend(ModelBackend):
         try:
             user = User.objects.get(username=username)
         except User.DoesNotExist:
-            user = User(username=username.lower(), auth_source=auth_source)
+            user = User(username=username, auth_source=auth_source)
             user.set_unusable_password()
             user.save()
 
@@ -179,7 +179,7 @@ class BasicBackend(ModelBackend):
 
     def authenticate(self, request, basic=None, **kwargs):
         bits = base64.b64decode(basic).decode().split(":")
-        username = bits[0]
+        username = bits[0].lower()
         password = ":".join(bits[1:])
         user = None
 

--- a/apps/core/management/commands/entry_defaults.py
+++ b/apps/core/management/commands/entry_defaults.py
@@ -1,0 +1,23 @@
+from django.core.management import BaseCommand
+
+from apps.core.models import Entry
+from apps.core.models.entry import default_entry_config
+
+
+class Command(BaseCommand):
+    help = "Check if all entries have all config keys set"
+
+    def handle(self, *args, **options):
+        defaults = default_entry_config()
+
+        for entry in Entry.objects.all():
+            updated = False
+
+            for key in defaults.keys():
+                if key not in entry.config:
+                    entry.config[key] = defaults[key]
+                    self.stdout.write(f"Setting {key} to {defaults[key]} in {entry.id}")
+                    updated = True
+
+            if updated:
+                entry.save()

--- a/apps/core/models/entry.py
+++ b/apps/core/models/entry.py
@@ -110,4 +110,4 @@ def touch_parents(sender, instance: Entry, **kwargs):
     instance.feeds.update(touched_at=timezone.now())
 
 
-__all__ = ["Entry"]
+__all__ = ["Entry", "default_entry_config"]

--- a/conf/entrypoint.sh
+++ b/conf/entrypoint.sh
@@ -9,5 +9,6 @@ done
 
 python3 manage.py migrate
 python3 manage.py setup
+python3 manage.py entry_defaults
 
 supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
- **Added**: `entry_defaults` management command introduced and executed on server start
- **Changed**: License files
- **Fixed**: Catch `FileNotFoundError` in `/v1/data` endpoints
- **Fixed**: Implicit Category creation in new Entry
- **Fixed**: No not rely on existence of all keys in ISBN introspection driver
- **Fixed**: Keep usernames from LDAP always in lower