### PR TITLE
Docker - PostgreSQL 17.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 This changelog suppose to follow rules defined in the [changelog.md](https://changelog.md)
 
-## 0.12.0 : 2025-04-10
+## 0.12.1 : 2025-03-13
+
+- **Fixed**: You same PostgreSQL client binaries major version as on server (17.x)
+
+## 0.12.0 : 2025-03-10
 
 - **Added**: Server-side annotation render for user acquisitions using `?annotations=true` query param
 - **Added**: Backup management command and Celery beat

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3.13-slim AS builder
 
 # System setup
-RUN apt update -y && apt install -y libffi-dev build-essential libsasl2-dev libpq-dev libjpeg-dev libldap-dev
+RUN apt update -y && apt install -y libffi-dev build-essential libsasl2-dev libjpeg-dev libldap-dev postgresql-common && \
+    /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && \
+    apt update -y && \
+    apt install -y postgresql-client-17 postgresql-server-dev-17
 
 # https://github.com/python-ldap/python-ldap/issues/432
 RUN echo 'INPUT ( libldap.so )' > /usr/lib/libldap_r.so
@@ -21,7 +24,10 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 # Dependencies
-RUN apt update -y && apt install -y supervisor curl postgresql-client libjpeg-tools argon2 tzdata ldap-utils swig
+RUN apt update -y && apt install -y supervisor curl libjpeg-tools argon2 tzdata ldap-utils swig postgresql-common && \
+    /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && \
+    apt update -y && \
+    apt install -y postgresql-client-17
 
 WORKDIR /usr/src/app
 
@@ -29,7 +35,7 @@ COPY . .
 COPY --from=builder /root/.local /root/.local
 
 ENV PATH=/root/.local/bin:$PATH
-ENV GUNICORN_CMD_ARGS '--workers 4 -b 0.0.0.0:8000'
+ENV GUNICORN_CMD_ARGS='--workers 4 -b 0.0.0.0:8000'
 
 RUN date -I > BUILD.txt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evil_flowers_catalog"
-version = "0.12.0"
+version = "0.12.1"
 description = "Publication catalog compatible with OPDS"
 authors = ["Jakub Dubec <jakub.dubec@stuba.sk>"]
 


### PR DESCRIPTION
Use PostgreSQL 17.x client libraries (because of pg_dump compatibility)